### PR TITLE
Exit with error status on abort and parallel abort

### DIFF
--- a/geogrid/src/module_debug.F
+++ b/geogrid/src/module_debug.F
@@ -320,7 +320,7 @@ module module_debug
 #ifdef _METGRID 
             call parallel_abort()
 #endif
-            stop
+            error stop
          end if
 
       end if

--- a/geogrid/src/parallel_module.F
+++ b/geogrid/src/parallel_module.F
@@ -1038,7 +1038,7 @@ include 'mpif.h'
       call MPI_Abort(MPI_COMM_WORLD, mpi_errcode, mpi_ierr)
 #endif
 
-      stop
+      error stop
 
    end subroutine parallel_abort
  


### PR DESCRIPTION
Fix for https://github.com/wrf-model/WPS/issues/252

Note that
- `geogrid/util/plotgrid/src/module_debug.F`
- `geogrid/util/plotgrid/src/parallel_module.F`
- `metgrid/src/module_debug.F`
- `metgrid/src/parallel_module.F`

are all symlinks to the original in `geogrid/src`


### To test this:

* recompile WPS (`./compile`)
* in `namelist.wps` set `opt_geogrid_tbl_path = '/home/invalid/path/'`
* run `./geogrid.exe`; it should print:
```
ERROR: Could not open GEOGRID.TBL
ERROR STOP
 ...
```
and a backtrace
* run `echo $?` to get the exit status of the last command; it should print `1`
